### PR TITLE
Kubernetes networks*

### DIFF
--- a/kubernetes-networks/README.md
+++ b/kubernetes-networks/README.md
@@ -1,0 +1,35 @@
+- Добавление проверок Pod
+  > Почему следующая конфигурация валидна, но не имеет смысла?
+
+```
+livenessProbe:
+  exec:
+command:
+- 'sh'
+- '-c'
+- 'ps aux | grep my_web_server_process'
+```
+
+Если это проверка для главного процесса с PID 1, то проверка не имеет смысла. Потому что в случае его падения весь контейнер будет польность перезапущен.
+
+> Бывают ли ситуации, когда она все-таки имеет смысл?
+
+Возможо использование подобной проверки, если речь о дочернем процессе внутри контейнера
+
+# MetalLB || Проверка конфигурации
+
+Добавление маршрута на миникуб
+
+```
+sudo route -n add 172.17.0.0/16 $(minikube ip)
+```
+
+[Про ipvs](https://kubernetes.io/blog/2018/07/09/ipvs-based-in-cluster-load-balancing-deep-dive/)
+
+
+# Про OpenResty
+```
+In a relatively big clusters with frequently deploying apps this feature saves significant number of Nginx reloads which can otherwise affect response latency, load balancing quality (after every reload Nginx resets the state of load balancing) and so on.
+```
+
+

--- a/kubernetes-networks/coredns/coredns-svc-lb.yaml
+++ b/kubernetes-networks/coredns/coredns-svc-lb.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-svc-udp-lb
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: core-key
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  ports:
+    - protocol: UDP
+      port: 53
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-svc-tcp-lb
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: core-key
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 53

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default 
+      protocol: layer2 
+      addresses: 
+      - "172.17.255.1-172.17.255.255"

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,17 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  ports:
+    - { name: http, port: 80, targetPort: http }
+    - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: negleb/otus-k8s-hw-2_web-app:1.0.0
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8000
+          livenessProbe:
+            tcpSocket: { port: 8000 }
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      initContainers:
+        - name: init-index-page
+          image: busybox:1.31.0
+          command:
+            [
+              "sh",
+              "-c",
+              "wget -O- https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Introduction-to-Kubernetes/wget.sh | sh",
+            ]
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          emptyDir: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /web
+            backend:
+              serviceName: web-svc
+              servicePort: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [x] Задание со * DNS через MetalLB
 - [ ] Задание со * Ingress для Dashboard
 - [ ] Задание со * Canary для Ingress

## В процессе сделано:
 - Описал Service
 - Переключил k8s в ipvs режим
 - Установил MetalLB 
 - Сделал CoreDNS доступным вне minikube по tcp & udp
 - Изучил Ingress & Headless services 

## Как запустить проект:
- Добавление маршрута на миникуб
```
sudo route -n add 172.17.0.0/16 $(minikube ip)
```


## Как проверить работоспособность:
 - http://$(minikube ip/web/index.html

## PR checklist:
 - [ ] Выставлен label с номером домашнего задания

## Вопросы

- Почему следующая конфигурация валидна, но не имеет смысла?

```
livenessProbe:
  exec:
command:
- 'sh'
- '-c'
- 'ps aux | grep my_web_server_process'
```

Если это проверка для главного процесса с PID 1, то проверка не имеет смысла. Потому что в случае его падения весь контейнер будет польность перезапущен.

- Бывают ли ситуации, когда она все-таки имеет смысл?

Возможо использование подобной проверки, если речь о дочернем процессе внутри контейнера